### PR TITLE
Upgrade Presto version (306)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,16 @@ presto for Cloudera Manager parcel
 
 # Build
 
-`mvn package`
+```
+mvn package
+```
+
+- By default, use `prestosql/presto` repository ( https://github.com/prestosql/presto )
+- If you want to use `prestodb/presto` repository ( https://github.com/prestodb/presto ), configure properties for pom
+  - e.g.) use `prestodb/presto` version 0.218:
+```
+mvn -Dpresto.url.base="https://repo1.maven.org/maven2/com/facebook/presto" -Dpresto.version=0.218 package
+```
 
 # Deploy
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,11 @@
   </build>
 
   <properties>
-    <presto.version>0.189</presto.version>
-    <jdk.version>8u151</jdk.version>
-    <jdk.build>b12</jdk.build>
-    <jdk.hash>e758a0de34e24606bca991d704f6dcbf</jdk.hash>
+    <presto.version>306</presto.version>
+    <presto.url.base>https://repo1.maven.org/maven2/io/prestosql</presto.url.base>
+    <jdk.version>8u201</jdk.version>
+    <jdk.build>b09</jdk.build>
+    <jdk.hash>42970487e3af4f5aa5bca3f542482c60</jdk.hash>
     <parcel.version>${presto.version}.presto${project.version}</parcel.version>
   </properties>
 </project>

--- a/src/main/resources/assemble.sh
+++ b/src/main/resources/assemble.sh
@@ -17,7 +17,7 @@ rm -rf $decompressed_dir
 
 
 presto_download_name="presto.tar.gz"
-presto_download_url="https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${presto.version}/presto-server-${presto.version}.tar.gz"
+presto_download_url="${presto.url.base}/presto-server/${presto.version}/presto-server-${presto.version}.tar.gz"
 
 curl -L -o $presto_download_name $presto_download_url
 mkdir $decompressed_dir
@@ -29,7 +29,7 @@ for file in `\ls $decompressed_dir/$presto_dir`; do
 done
 rm -rf $decompressed_dir
 
-presto_cli_download_url="https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${presto.version}/presto-cli-${presto.version}-executable.jar"
+presto_cli_download_url="${presto.url.base}/presto-cli/${presto.version}/presto-cli-${presto.version}-executable.jar"
 
 curl -L -O $presto_cli_download_url
 mv presto-cli-${presto.version}-executable.jar ${parcel_name}/bin/


### PR DESCRIPTION
- Switch Presto repository to prestosql/presto
  - and upgrade default Presto version to 306
- Add properties for pom
  - `presto.url.base` : use for switch Presto repository